### PR TITLE
ci: npm trusted publishing (OIDC) and action runtime updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -35,7 +35,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -72,13 +72,16 @@ jobs:
     needs: [ci, tag-release]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'todesstoss/create-use-context'
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -88,12 +91,8 @@ jobs:
 
       - run: pnpm run build
 
-      - name: Configure npm auth
-        run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Install npm CLI with OIDC trusted publishing
+        run: npm install -g npm@^11.5.1
 
-      - name: Publish to npm
-        run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm (OIDC)
+        run: npm publish --access public


### PR DESCRIPTION
## Summary

- Publish to npm using **OIDC trusted publishing**: `id-token: write`, no `NPM_TOKEN` (token auth was causing `EOTP` with 2FA).
- Install **npm >= 11.5.1** before publish; run **`npm publish`** so OIDC is used reliably.
- Bump **actions/checkout**, **actions/setup-node**, and **pnpm/action-setup** to versions that run on Node.js 24 (avoids the Node 20 deprecation warning for those actions).

## Test plan

- [ ] Merge after **Trusted Publisher** is configured on npm for this repo and workflow file **`ci.yml`**.
- [ ] Confirm publish job succeeds on push to `master` (or re-run workflow).
