### PR TITLE
ci(publish): fix npm upgrade failure on publish job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,16 +83,13 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm run build
-
-      - name: Install npm CLI with OIDC trusted publishing
-        run: npm install -g npm@^11.5.1
 
       - name: Publish to npm (OIDC)
         run: npm publish --access public


### PR DESCRIPTION
## Summary

The merged OIDC workflow still ran `npm install -g npm@^11.5.1`, which can break the hostedtoolcache install (`MODULE_NOT_FOUND` / `promise-retry`).

Use **Node 24** for the publish job only (bundled **npm 11.x**, satisfies trusted publishing) and remove the global npm upgrade step.

## Test plan

- [ ] Merge and confirm the publish job passes on the next `master` push.