### PR TITLE
fix: widen react peer range (3.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.1
+
+### Fix
+
+- Widen **`react` peer dependency** to `>=16.8.0` so npm can install with React 17, 18, and 19 (`^16.8.0` only matched 16.x and triggered `ERESOLVE` with React 19).
+
 ## 3.0.0
 
 ### Breaking changes

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "name": "create-use-context",
   "packageManager": "pnpm@10.33.0",
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": ">=16.8.0"
   },
   "repository": {
     "type": "git",
@@ -61,5 +61,5 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "version": "3.0.0"
+  "version": "3.0.1"
 }


### PR DESCRIPTION
## Summary

- Set **`peerDependencies.react`** to **`>=16.8.0`** so installs with React 17, 18, and 19 satisfy the peer ( **`^16.8.0`** only matched 16.x and caused **`ERESOLVE`** with React 19).
- Release **3.0.1** with a short **CHANGELOG** entry.

## Test plan

- [ ] Merge to `master`; release automation publishes **3.0.1** when version + CHANGELOG are in place.
- [ ] In a React 19 app, `npm install create-use-context@3.0.1` completes without peer resolution errors.